### PR TITLE
Added new Audit Client role

### DIFF
--- a/php/api/class-api-bootstrap.php
+++ b/php/api/class-api-bootstrap.php
@@ -87,7 +87,7 @@ class API_Bootstrap extends Base {
 	}
 
 	/**
-	 * Register a new role for API Client.
+	 * Register new roles for API Client.
 	 *
 	 * @action init
 	 */
@@ -106,6 +106,21 @@ class API_Bootstrap extends Base {
 
 		// Add API Client role.
 		add_role( 'api_client', __( 'API Client', 'tide-api' ), $capabilities );
+
+		// Caps for Audit Client role.
+		$capabilities = array(
+			'delete_posts'           => true,
+			'delete_published_posts' => true,
+			'edit_posts'             => true,
+			'edit_published_posts'   => true,
+			'edit_others_posts'      => true,
+			'publish_posts'          => true,
+			'read'                   => true,
+			'upload_files'           => true,
+		);
+
+		// Add API Client role.
+		add_role( 'audit_client', __( 'Audit Client', 'tide-api' ), $capabilities );
 	}
 
 	/**

--- a/php/api/class-api-bootstrap.php
+++ b/php/api/class-api-bootstrap.php
@@ -108,16 +108,7 @@ class API_Bootstrap extends Base {
 		add_role( 'api_client', __( 'API Client', 'tide-api' ), $capabilities );
 
 		// Caps for Audit Client role.
-		$capabilities = array(
-			'delete_posts'           => true,
-			'delete_published_posts' => true,
-			'edit_posts'             => true,
-			'edit_published_posts'   => true,
-			'edit_others_posts'      => true,
-			'publish_posts'          => true,
-			'read'                   => true,
-			'upload_files'           => true,
-		);
+		$capabilities['edit_others_posts'] = true;
 
 		// Add API Client role.
 		add_role( 'audit_client', __( 'Audit Client', 'tide-api' ), $capabilities );

--- a/php/api/class-api-bootstrap.php
+++ b/php/api/class-api-bootstrap.php
@@ -108,7 +108,20 @@ class API_Bootstrap extends Base {
 		add_role( 'api_client', __( 'API Client', 'tide-api' ), $capabilities );
 
 		// Caps for Audit Client role.
-		$capabilities['edit_others_posts'] = true;
+		$capabilities = array(
+			'delete_others_posts'    => true,
+			'delete_posts'           => true,
+			'delete_private_posts'   => true,
+			'delete_published_posts' => true,
+			'edit_others_posts'      => true,
+			'edit_posts'             => true,
+			'edit_private_posts'     => true,
+			'edit_published_posts'   => true,
+			'publish_posts'          => true,
+			'read_private_posts'     => true,
+			'read'                   => true,
+			'upload_files'           => true,
+		);
 
 		// Add API Client role.
 		add_role( 'audit_client', __( 'Audit Client', 'tide-api' ), $capabilities );

--- a/php/api/controller/class-audit-posts-controller.php
+++ b/php/api/controller/class-audit-posts-controller.php
@@ -662,7 +662,13 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 		// Determine an item's visibility and allow users with the right capabilities to read this post.
 		$visibility   = get_post_meta( $post->ID, 'visibility', true );
 		$current_user = wp_get_current_user();
-		$is_author    = $post->post_author === $current_user->ID && in_array( 'api_client', (array) $current_user->roles, true );
+		$is_author    = (
+			! is_wp_error( $current_user )
+			&&
+			absint( $post->post_author ) === absint( $current_user->ID )
+			&&
+			in_array( 'api_client', (array) $current_user->roles, true )
+		);
 
 		if ( 'private' === $visibility && ! ( $is_author || current_user_can( 'read_private_posts' ) ) ) {
 			$allowed = false;
@@ -735,7 +741,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	protected function elevate_audit_client_permission( $allowed ) {
 		$current_user = wp_get_current_user();
 
-		if ( in_array( 'audit_client', (array) $current_user->roles, true ) ) {
+		if ( ! is_wp_error( $current_user ) && in_array( 'audit_client', (array) $current_user->roles, true ) ) {
 			$allowed = true;
 		}
 

--- a/php/api/controller/class-audit-posts-controller.php
+++ b/php/api/controller/class-audit-posts-controller.php
@@ -667,7 +667,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 			&&
 			absint( $post->post_author ) === absint( $current_user->ID )
 			&&
-			in_array( 'api_client', (array) $current_user->roles, true )
+			$current_user->has_cap( 'api_client' )
 		);
 
 		if ( 'private' === $visibility && ! ( $is_author || current_user_can( 'read_private_posts' ) ) ) {
@@ -741,7 +741,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	protected function elevate_audit_client_permission( $allowed ) {
 		$current_user = wp_get_current_user();
 
-		if ( ! is_wp_error( $current_user ) && in_array( 'audit_client', (array) $current_user->roles, true ) ) {
+		if ( ! is_wp_error( $current_user ) && $current_user->has_cap( 'audit_client' ) ) {
 			$allowed = true;
 		}
 

--- a/php/api/controller/class-audit-posts-controller.php
+++ b/php/api/controller/class-audit-posts-controller.php
@@ -645,7 +645,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	public function get_items_permissions_check( $request ) {
 		$allowed = parent::get_items_permissions_check( $request );
 
-		return apply_filters( 'tide_api_audit_can_get_items', $allowed, $this );
+		return apply_filters( 'tide_api_audit_can_get_items', self::elevate_audit_client_permission( $allowed ), $this );
 	}
 
 	/**
@@ -659,19 +659,16 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	public function check_read_permission( $post ) {
 		$allowed = parent::check_read_permission( $post );
 
-		/**
-		 * Determine an item's visibility.
-		 * Still allowed users with the right capabilities to read this post.
-		 */
+		// Determine an item's visibility and allow users with the right capabilities to read this post.
 		$visibility   = get_post_meta( $post->ID, 'visibility', true );
 		$current_user = wp_get_current_user();
 		$is_author    = $post->post_author === $current_user->ID && in_array( 'api_client', (array) $current_user->roles, true );
 
-		if ( 'public' !== $visibility && ( ! $is_author || ! current_user_can( 'read_private_posts' ) ) ) {
+		if ( 'private' === $visibility && ! ( $is_author || current_user_can( 'read_private_posts' ) ) ) {
 			$allowed = false;
 		}
 
-		return apply_filters( 'tide_api_audit_can_read', $allowed, $post );
+		return apply_filters( 'tide_api_audit_can_read', self::elevate_audit_client_permission( $allowed ), $post );
 	}
 
 	/**
@@ -684,7 +681,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	protected function check_update_permission( $post ) {
 		$allowed = parent::check_update_permission( $post );
 
-		return apply_filters( 'tide_api_audit_can_update', $allowed, $post );
+		return apply_filters( 'tide_api_audit_can_update', self::elevate_audit_client_permission( $allowed ), $post );
 	}
 
 	/**
@@ -697,7 +694,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	protected function check_create_permission( $post ) {
 		$allowed = parent::check_create_permission( $post );
 
-		return apply_filters( 'tide_api_audit_can_create', $allowed, $post );
+		return apply_filters( 'tide_api_audit_can_create', self::elevate_audit_client_permission( $allowed ), $post );
 	}
 
 	/**
@@ -710,7 +707,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	protected function check_delete_permission( $post ) {
 		$allowed = parent::check_delete_permission( $post );
 
-		return apply_filters( 'tide_api_audit_can_delete', $allowed, $post );
+		return apply_filters( 'tide_api_audit_can_delete', self::elevate_audit_client_permission( $allowed ), $post );
 	}
 
 	/**
@@ -725,7 +722,24 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 	protected function check_assign_terms_permission( $request ) {
 		$allowed = parent::check_assign_terms_permission( $request );
 
-		return apply_filters( 'tide_api_audit_can_assign_terms', $allowed, $request );
+		return apply_filters( 'tide_api_audit_can_assign_terms', self::elevate_audit_client_permission( $allowed ), $request );
+	}
+
+	/**
+	 * Checks if the current user is an audit_client and elevate permissions.
+	 *
+	 * @param bool $allowed Whether the current user is allowed to modify a post.
+	 *
+	 * @return bool Whether the current user is an audit_client.
+	 */
+	protected function elevate_audit_client_permission( $allowed ) {
+		$current_user = wp_get_current_user();
+
+		if ( in_array( 'audit_client', (array) $current_user->roles, true ) ) {
+			$allowed = true;
+		}
+
+		return $allowed;
 	}
 
 	/**

--- a/php/authentication/class-keypair-auth.php
+++ b/php/authentication/class-keypair-auth.php
@@ -188,6 +188,8 @@ class Keypair_Auth extends Base {
 		unset( $user->cap_key );
 		unset( $user->filter );
 
+		wp_set_current_user( $user->ID );
+
 		return $user;
 	}
 

--- a/tests/php/api/class-test-audit-posts-controller.php
+++ b/tests/php/api/class-test-audit-posts-controller.php
@@ -209,7 +209,7 @@ class Test_Audit_Posts_Controller extends WP_Test_REST_Controller_TestCase {
 	}
 
 	/**
-	 * Test getting an item without permissions.
+	 * Test getting an item with permissions.
 	 *
 	 * @covers ::get_item_permissions_check_altid()
 	 */

--- a/tests/php/api/class-test-audit-posts-controller.php
+++ b/tests/php/api/class-test-audit-posts-controller.php
@@ -30,6 +30,13 @@ class Test_Audit_Posts_Controller extends WP_Test_REST_Controller_TestCase {
 	 */
 	protected static $api_client_id;
 
+	/**
+	 * Audit client user ID.
+	 *
+	 * @var int
+	 */
+	protected static $audit_client_id;
+
 	const CHECKSUM_PATTERN = '[a-fA-F\d]{64}';
 
 	/**
@@ -41,6 +48,11 @@ class Test_Audit_Posts_Controller extends WP_Test_REST_Controller_TestCase {
 		self::$api_client_id = $factory->user->create( array(
 			'role' => 'api_client',
 		) );
+
+		self::$audit_client_id = $factory->user->create( array(
+			'user_login' => 'audit-server',
+			'role'       => 'audit_client',
+		) );
 	}
 
 	/**
@@ -48,6 +60,7 @@ class Test_Audit_Posts_Controller extends WP_Test_REST_Controller_TestCase {
 	 */
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$api_client_id );
+		self::delete_user( self::$audit_client_id );
 	}
 
 	/**
@@ -57,7 +70,7 @@ class Test_Audit_Posts_Controller extends WP_Test_REST_Controller_TestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		wp_set_current_user( self::$api_client_id );
+		wp_set_current_user( self::$audit_client_id );
 	}
 
 	/**
@@ -110,10 +123,6 @@ class Test_Audit_Posts_Controller extends WP_Test_REST_Controller_TestCase {
 	 * @covers ::get_item_altid()
 	 */
 	public function test_get_item_private_visibility() {
-		$this->markTestSkipped(
-			'This test is broken because the current user is not matching the post_author ID.'
-		);
-
 		$audit_id = $this->factory()->post->create( array(
 			'post_type'   => 'audit',
 			'post_author' => self::$api_client_id,
@@ -160,8 +169,38 @@ class Test_Audit_Posts_Controller extends WP_Test_REST_Controller_TestCase {
 			'post_author' => self::$api_client_id,
 		) );
 
+		wp_set_current_user( $this->factory()->post->create( array(
+			'role' => 'subscriber',
+		) ) );
+
 		$checksum = '7d9e35c703a7f8c6def92d5dbcf4a85a9271ce390474339cef7e404abb600000';
 		update_post_meta( $audit_id, 'checksum', $checksum );
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/tide/v1/audit/%s', $checksum ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test getting an item without permissions.
+	 *
+	 * @covers ::get_item_permissions_check_altid()
+	 */
+	public function test_get_item_permissions_private_visibility() {
+		$audit_id = $this->factory()->post->create( array(
+			'post_type'   => 'audit',
+			'post_author' => self::$api_client_id,
+		) );
+
+		wp_set_current_user( $this->factory()->post->create( array(
+			'role' => 'subscriber',
+		) ) );
+
+		$checksum = '7d9e35c703a7f8c6def92d5dbcf4a85a9271ce390474339cef7e404abb600000';
+		update_post_meta( $audit_id, 'checksum', $checksum );
+		update_post_meta( $audit_id, 'visibility', 'private' );
 
 		$request  = new WP_REST_Request( 'GET', sprintf( '/tide/v1/audit/%s', $checksum ) );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
Adding a new Audit Client role with `edit_others_posts` caps.

The `build.sh` file will be updated in another PR on the wptide/api repo to ensure the `audit-server` user uses this role.
