### PR TITLE
Add additional filter to get_altid_post return value.

### DIFF
--- a/php/api/controller/class-audit-posts-controller.php
+++ b/php/api/controller/class-audit-posts-controller.php
@@ -1134,12 +1134,14 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 		$post = new \WP_Query( $args );
 
 		if ( is_wp_error( $post ) || empty( $post ) || 0 === $post->post_count ) {
-			return new \WP_Error( 'rest_post_invalid_altid_lookup', __( 'Invalid post lookup.', 'tide-api' ), array(
+			$post = new \WP_Error( 'rest_post_invalid_altid_lookup', __( 'Invalid post lookup.', 'tide-api' ), array(
 				'status' => 404,
 			) );
+		} else {
+			$post = array_shift( $post->posts );
 		}
 
-		return array_shift( $post->posts );
+		return apply_filters( 'tide_api_modify_pre_response_post', $post, $request );
 	}
 
 	/**

--- a/php/api/controller/class-audit-posts-controller.php
+++ b/php/api/controller/class-audit-posts-controller.php
@@ -1141,7 +1141,7 @@ class Audit_Posts_Controller extends \WP_REST_Posts_Controller {
 			$post = array_shift( $post->posts );
 		}
 
-		return apply_filters( 'tide_api_modify_pre_response_post', $post, $request );
+		return apply_filters( 'tide_api_get_altid_post', $post, $request );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a new filter to the Audit_Post_Controller::get_altid_post() return value: `tide_api_modify_pre_response_post`

This allows the ability to intercept a potential error, perform some actions and in conjunction with `tide_api_modify_response` give an alternate response to the API request.

Use case: Provide simple webhook mechanism to create audit via visiting an endpoint for an item that does not exists.